### PR TITLE
Deserialization Testnet & Witness Script Highlight

### DIFF
--- a/src/comp/Transactions/Helper.tsx
+++ b/src/comp/Transactions/Helper.tsx
@@ -53,6 +53,7 @@ export enum TxTextSectionType {
   outputPubKeySize = "outputScriptPubKeySize",
   outputPubKeyScript = "outputScriptPubKey",
   /* Witness Fields */
+  witnessScript = "witnessScript",
   witnessSize = "witnessSize",
   witnessElementSize = "witnessElementSize",
   witnessElementValue = "witnessElementValue",
@@ -109,7 +110,8 @@ export const TxTextSection = ({
     // if the user is hovering over the first character in a script we need to kinda highlight the whole script
     if (
       transactionItem.item.type === TxTextSectionType.inputScriptSig ||
-      transactionItem.item.type === TxTextSectionType.outputPubKeyScript
+      transactionItem.item.type === TxTextSectionType.outputPubKeyScript ||
+      transactionItem.item.type === TxTextSectionType.witnessScript
     ) {
       // get the whole content of this script
       const wholeScript = transactionItem.item.value;


### PR DESCRIPTION
This PR addresses two open issues mentioned in #131:

1. Testnet items now work (though this is a temporary workaround since it only works on fail - we could change this from UI)
2. First character in Witness now mentions the entire WitnessScript, same as the whole script for SigScript & whole script for PubKeyScript