### PR TITLE
feat: improved the multisig tool UX for adding example keys

### DIFF
--- a/src/comp/MultisigGenerator/MultisigGenerator.tsx
+++ b/src/comp/MultisigGenerator/MultisigGenerator.tsx
@@ -9,7 +9,7 @@ import {
   createTaprootMultisig,
   createTaprootScriptPathMultisig,
 } from "./bitcoinUtils";
-import SampleKeys from "./SampleKeys";
+import { SAMPLE_KEYS } from "./SampleKeys";
 
 // Define the types of multisig addresses we can generate
 export enum MultisigType {
@@ -60,6 +60,25 @@ const MultisigGenerator = () => {
     const newPublicKeys = [...publicKeys];
     newPublicKeys[index] = value;
     setPublicKeys(newPublicKeys);
+  };
+
+  // Generate a random key for a specific index
+  const generateRandomKey = async (index: number) => {
+    // I'm just generating this key from the sample keys set for now
+    const needsCompressed =
+      scriptType === MultisigType.P2TR ||
+      scriptType === MultisigType.P2TR_SCRIPT;
+
+    // Get a random key from the sample keys
+    let availableKeys = needsCompressed
+      ? SAMPLE_KEYS.filter(
+          (key) => key.startsWith("02") || key.startsWith("03")
+        ) // Only compressed keys
+      : SAMPLE_KEYS; // All keys
+
+    const randomIndex = Math.floor(Math.random() * availableKeys.length);
+    const newKey = availableKeys[randomIndex];
+    updatePublicKey(index, newKey);
   };
 
   // Validate m and n values
@@ -306,20 +325,12 @@ const MultisigGenerator = () => {
             <p className="font-bold text-black">Public Keys</p>
             <p className="ml-1 font-extralight text-black">(input)</p>
           </div>
-          <div className="flex space-x-2">
-            <button
-              onClick={addPublicKey}
-              className="hover:text-orange-600 text-sm font-medium text-[#F79327]"
-            >
-              Add Key
-            </button>
-            <button
-              onClick={() => setShowSampleKeys(!showSampleKeys)}
-              className="hover:text-orange-600 text-sm font-medium text-[#F79327]"
-            >
-              {showSampleKeys ? "Hide Sample Keys" : "Show Sample Keys"}
-            </button>
-          </div>
+          <button
+            onClick={addPublicKey}
+            className="hover:text-orange-600 text-sm font-medium text-[#F79327]"
+          >
+            Add Key
+          </button>
         </div>
         <div className="space-y-3">
           {publicKeys.map((key, index) => (
@@ -334,9 +345,14 @@ const MultisigGenerator = () => {
                   value={key}
                   onChange={(e) => updatePublicKey(index, e.target.value)}
                   className="w-full rounded-full bg-[#F3F3F3] px-3 text-[14px] font-extralight text-black focus:outline-none"
-                  onFocus={() => setCurrentKeyIndex(index)}
                 />
               </div>
+              <button
+                onClick={() => generateRandomKey(index)}
+                className="ml-2 rounded-full bg-[#0C071D] px-3 py-1 text-sm text-white hover:bg-[#1A1A2E]"
+              >
+                Generate
+              </button>
               {publicKeys.length > 1 && (
                 <button
                   onClick={() => removePublicKey(index)}
@@ -349,15 +365,6 @@ const MultisigGenerator = () => {
           ))}
         </div>
       </div>
-
-      {/* Sample Keys */}
-      {showSampleKeys && (
-        <SampleKeys
-          onSelectKey={handleSelectSampleKey}
-          copyToClipboard={copyToClipboard}
-          isCopied={isCopied}
-        />
-      )}
 
       {/* Error Message */}
       {error && (

--- a/src/comp/MultisigGenerator/SampleKeys.tsx
+++ b/src/comp/MultisigGenerator/SampleKeys.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 // Sample keys for Bitcoin multisig testing
 // These are public keys in compressed format (33 bytes, 66 hex chars)
-const SAMPLE_KEYS = [
+export const SAMPLE_KEYS = [
   // Compressed public keys (for all address types)
   "02e9af6073d5c1cb5234b9fd7b8bc35e640f9fda28589d84d1640b4c431a4c4e5a",
   "029fcd29f189f668cbe8b06b9ab3593b68d43456f27a5d1fb624ad1f98ca7424ee",


### PR DESCRIPTION
I removed the sample keys components and created a button to generate the key for the particular input field. 

<img width="1290" alt="Screenshot 2025-03-18 at 07 30 35" src="https://github.com/user-attachments/assets/bde51a1d-8343-43f7-85af-5e3af93ea118" />
